### PR TITLE
Fix remove delta shifts

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ To conceal a data-vector you need the following elements:
 
 * A dictionary of the nuisance parameters used in the likelihood (soon to be deprecated)
 
-* A Firecrown Likelihood, which takes a SACC data-vector (see more below)
+* A Firecrown Likelihood, which takes a SACC data-vector (see more below). It can be either a path to the python file containing the likelihood or the module itself.
 
 * A dictionary of cosmological parameters to be shifted in the format:
     
@@ -25,7 +25,9 @@ To conceal a data-vector you need the following elements:
         # or for a determinist shift (used for debugging):
         {'PARAM_Y': Y_VALUE, 'PARAM_Z': Z_VALUE}
 
-* A random seed
+* A SACC data-vector
+
+* A random seed as int or string
 
 .. attention::
    **Likelihood Requirements**
@@ -45,7 +47,12 @@ To conceal a data-vector you need the following elements:
 
     The likelihood module also must have a method ``.compute_theory_vector(ModellingTools)`` which calls for the calculation of the theory vector inside the likelihood object. 
 
-    The likelihood can be provided either as a path to the python file containing the ``build_likelihood`` function or as a python module. In the latter case, the module must be imported.
+.. danger::
+    **Likelihoods with hardcoded sacc files:**
+
+    If you provide a Firecrown likelihood with a hardcoded path to a sacc file as the data-vector, **Smokescreen will conceal the hardcoded sacc file and not the one you provided**. This is because the likelihood is built with the hardcoded path. Firecrown currently has not checks to avoid a hardcoded sacc file in the ``build_likelihood(...)`` function. To avoid this, please build the likelihood as described above.
+
+The likelihood can be provided either as a path to the python file containing the ``build_likelihood`` function or as a python module. In the latter case, the module must be imported.
 
 TL;DR: Check the `Smokescreen notebooks folder <https://github.com/LSSTDESC/Smokescreen/tree/main/notebooks>`_ for a couple of examples.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -130,3 +130,10 @@ The smokescreen module can be used to blind the data-vector measurements. The mo
    # conceals (blinds) the data vector
    smoke.calculate_concealing_factor()
    concealed_dv = smoke.apply_concealing_to_likelihood_datavec()
+
+Posterior Concealment (blinding)
+---------------------------------
+
+.. warning::
+
+    **UNDER DEVELOPMENT**

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,17 +1,36 @@
 Usage
 ======
 
-Currently, only data vector concealment is implemented in Smokescreen. Posterior level concealment is under development.
+Currently, only data vector concealment is implemented in Smokescreen. Posterior-level concealment is under development.
 
 Data Vector Concealment (blinding)
 -----------------------------------
 
 The `Smokescreen` library provides a method for blinding data vectors. This method is based on the `Muir et al. (2021) <https://arxiv.org/abs/1911.05929>`_ data-vector blinding method.
 
+To conceal a data-vector you need the following elements:
+
+* A CCL cosmology object
+
+* A dictionary of the nuisance parameters used in the likelihood (soon to be deprecated)
+
+* A Firecrown Likelihood, which takes a SACC data-vector (see more below)
+
+* A dictionary of cosmological parameters to be shifted in the format:
+    
+      .. code-block:: python
+
+        # for a random uniform parameter shift:
+        {'PARAM_Y': (Y_MIN, Y_MAX), 'PARAM_Z': (Z_MIN, Z_MAX)}
+        # or for a determinist shift (used for debugging):
+        {'PARAM_Y': Y_VALUE, 'PARAM_Z': Z_VALUE}
+
+* A random seed
+
 .. attention::
    **Likelihood Requirements**
 
-   The blinding module requires the Firecrown likelihoods to be built with certain requirements. First we bust be able to build the likelihoods providing a `sacc <https://github.com/LSSTDESC/sacc/tree/master>`_ object with the measurements for the data-vector:
+   The blinding module requires the Firecrown likelihood to be built with certain requirements. First, we must be able to build the likelihood by providing a `sacc <https://github.com/LSSTDESC/sacc/tree/master>`_ object with the measurements for the data-vector:
 
     .. code-block:: python
 
@@ -30,15 +49,33 @@ The `Smokescreen` library provides a method for blinding data vectors. This meth
 
 TL;DR: Check the `Smokescreen notebooks folder <https://github.com/LSSTDESC/Smokescreen/tree/main/notebooks>`_ for a couple of examples.
 
-From the commandline
-~~~~~~~~~~~~~~~~~~~~
+From the command line
+~~~~~~~~~~~~~~~~~~~~~~
 The blinding module can be used to blind the data-vector measurements. The module can be used as follows:
 
 .. code-block:: bash
 
    python -m smokescreen --config configuration_file.yaml
 
-You can find an example of a configuration file in `examples/cosmic_shear/blind_cosmic_shear_example.yaml`. Or you can use the following command to create a template configuration file:
+You can find an example of a configuration file here: 
+
+.. code-block:: yaml
+
+    path_to_sacc: "./cosmicshear_sacc.fits"
+    likelihood_path: "./cosmicshear_likelihood.py"
+    systematics:
+        trc1_delta_z: 0.1
+        trc0_delta_z: 0.1
+    shifts_dict:
+        Omega_c: [0.20, 0.42]
+        sigma8: [0.67, 0.92]
+    seed: 2112
+    # only needed if you want a different reference cosmology
+    # than ccl.VanillaLCDM
+    reference_cosmology: 
+        sigma8: 0.85
+
+Or you can use the following command to create a template configuration file:
 
 .. code-block:: bash
 

--- a/examples/cosmic_shear/blind_cosmic_shear_example.yaml
+++ b/examples/cosmic_shear/blind_cosmic_shear_example.yaml
@@ -4,10 +4,10 @@ systematics:
   trc1_delta_z: 0.1
   trc0_delta_z: 0.1
 shifts_dict:
-  Omega_c: [-0.1, 0.2]
-  sigma8: [-0.1, 0.1]
+  Omega_c: [0.18, 0.34]
+  sigma8: [0.67, 0.95]
 seed: 2112
 # only needed if you want a different reference cosmology
 # than ccl.VanillaLCDM
 reference_cosmology: 
-  sigma8: 0.95
+  sigma8: 0.78

--- a/examples/supernovae/blind_sn_example.yaml
+++ b/examples/supernovae/blind_sn_example.yaml
@@ -3,8 +3,8 @@ likelihood_path: "./sn_likelihood.py"
 systematics:
   sn_ddf_sample_M: -19.3
 shifts_dict:
-  h: [-0.3, 0.3]
-  sigma8: [-0.1, 0.1]
+  h: [0.60, 0.80]
+  sigma8: [0.67, 0.95]
 seed: 2112
 # only needed if you want a different reference cosmology
 # than ccl.VanillaLCDM

--- a/notebooks/test_cosmicshear_example.ipynb
+++ b/notebooks/test_cosmicshear_example.ipynb
@@ -97,7 +97,7 @@
     "    \"trc1_delta_z\": 0.1,\n",
     "    \"trc0_delta_z\": 0.1,\n",
     "    }\n",
-    "shift_dict = {\"Omega_c\": (-0.1, 0.2), \"sigma8\": (-0.1, 0.1)}\n",
+    "shift_dict = {\"Omega_c\": (0.20, 0.34), \"sigma8\": (0.68, 0.91)}\n",
     "sck = ConcealDataVector(cosmo, syst_dict, cosmicshear_likelihood, shift_dict, sacc_data, **{'debug': True})"
    ]
   },

--- a/notebooks/test_supernova_example.ipynb
+++ b/notebooks/test_supernova_example.ipynb
@@ -94,7 +94,7 @@
     "syst_dict = {\n",
     "    \"sn_ddf_sample_M\": -19.3,\n",
     "    }\n",
-    "shift_dict = {\"h\": (-0.25, 0.25), \"Omega_c\": (-0.2, 0.2)}\n",
+    "shift_dict = {\"h\": (0.60, 0.80), \"Omega_c\": (0.21, 0.36)}\n",
     "sck = ConcealDataVector(cosmo, syst_dict, sn_likelihood, shift_dict, sacc_data, seed=6, **{'debug': True})"
    ]
   },

--- a/src/smokescreen/param_shifts.py
+++ b/src/smokescreen/param_shifts.py
@@ -62,12 +62,10 @@ def draw_flat_or_deterministic_param_shifts(cosmo, shifts_dict, seed):
     cosmo : pyccl.Cosmology
         Cosmology object.
     shift_dict : dict
-        Dictionary of parameter names and corresponding shift widths. If the
+        Dictionary of parameter names and corresponding shift. If the
         shifts are single values, it does a deterministic shift: PARAM = FIDUCIAL + SHIFT
         If the shifts are tuples of values, the dictionary values
         should be the (lower, upper) bounds of the shift widths: PARAM = U(a, b)
-        If the first valuee is negative, it is assumed that the parameter
-        is to be shifted from the fiducial value: PARAM = FIDUCIAL + U(-a, b)
     seed : int or str
         Random seed.
 
@@ -94,10 +92,7 @@ def draw_flat_or_deterministic_param_shifts(cosmo, shifts_dict, seed):
         if isinstance(value, tuple):
             # check if the tuple is of length 2
             if len(value) == 2:
-                if value[0] < 0:
-                    shifts[key] = cosmo[key] + np.random.uniform(value[0], value[1])
-                else:
-                    shifts[key] = np.random.uniform(value[0], value[1])
+                shifts[key] = np.random.uniform(value[0], value[1])
             else:
                 raise ValueError(f"Tuple {value} has to be of length 2")
         else:


### PR DESCRIPTION
Removed the ability to use "delta shifts", like `{'Omega_c': (-0.1, 0.1)}` as these could mess up things when using parameters that can be negative like `w0`. 

Also improved the documentation.