### PR TITLE
Include deploying latest release documentation

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - docs
+  release:
+    types: [published]
 jobs:
   build-docs:
     runs-on: ubuntu-latest
@@ -47,6 +49,49 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs') }}
+      with:
+        publish_branch: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/
+        force_orphan: true
+
+  build-docs-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+    - name: Install Miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-version: "latest"
+        python-version: '3.12'
+        channels: conda-forge
+        channel-priority: true
+        auto-update-conda: true
+        auto-activate-base: true
+    - name: Create and activate conda environment
+      shell: bash -l {0}
+      run: |
+        conda env create -f environment.yml
+        conda activate desc_smokescreen
+    - name: Install package with docs extra
+      shell: bash -l {0}
+      run: |
+        conda activate desc_smokescreen
+        python -m pip install --upgrade pip
+        python -m pip install .[docs]
+    - name: Build Sphinx documentation
+      shell: bash -l {0}
+      run: |
+        conda activate desc_smokescreen
+        cd docs
+        python -m sphinx -b html source build
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
       with:
         publish_branch: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ conda install -c conda-forge lsstdesc-smokescreen
 For developer installation or other instructions check the [documentation](https://lsstdesc.org/Smokescreen/installation.html).
 
 For questions contact @arthurmloureiro, @jessmuir, or @jablazek
+**Note:** The deployed documentation now includes the latest release along with the main branch.
 
 ---
 
 **Legacy 2pt Cosmosis Blinding**
 
 Legacy Blinding scripts for 2pt data vector blinding with Cosmosis moved to a [new repository](https://github.com/LSSTDESC/legacy_blinding).
-
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ html_theme_options = {
     'titles_only': False,
     'sticky_navigation': True,
     'navigation_depth': 4,
+    'version_selector': True,  # Enable version selector
 }
 
 html_css_files = [
@@ -49,3 +50,26 @@ html_static_path = ['_static']
 html_js_files = [
     'custom.js',
 ]
+
+# Add logic to differentiate between the main branch and the latest release
+import os
+import sys
+from datetime import datetime
+
+# Get the current branch or tag
+current_version = os.getenv('READTHEDOCS_VERSION', 'latest')
+
+# Set the version based on the current branch or tag
+if current_version == 'latest':
+    version = 'main'
+else:
+    version = current_version
+
+# Add the version to the context
+html_context = {
+    'current_version': version,
+    'versions': [
+        ('main', '/en/latest/'),
+        ('latest release', f'/en/{version}/'),
+    ],
+}


### PR DESCRIPTION
Related to #63

Add deployment of latest release documentation along with the main branch.

* Update `.github/workflows/build_docs.yml` to include a new job `build-docs-release` that triggers on release events and deploys the latest release documentation to the `gh-pages` branch.
* Modify `docs/source/conf.py` to handle multiple versions of documentation by adding logic to differentiate between the main branch and the latest release, and updating `html_theme_options` to include a version selector.
* Update `README.md` to mention that the deployed documentation now includes the latest release along with the main branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LSSTDESC/Smokescreen/pull/64?shareId=9a674632-6527-448f-ba2e-fa35d083e5c2).