### PR TITLE
fixed cli for determinist shift

### DIFF
--- a/src/smokescreen/__main__.py
+++ b/src/smokescreen/__main__.py
@@ -33,7 +33,7 @@ banner = rf"""
 
 def datavector_main(path_to_sacc: Path_fr,
                     likelihood_path: str,
-                    shifts_dict: Dict[str, Tuple[float, float]],
+                    shifts_dict: Dict[str, Union[float, Tuple[float, float]]],
                     systematics: dict = None,
                     shift_type: str = 'add',
                     shift_distribution: str = 'flat',


### PR DESCRIPTION
This pull request makes a small update to the type annotation for the `shifts_dict` parameter in the `datavector_main` function. Now, `shifts_dict` can accept values that are either a single `float` or a `Tuple[float, float]`, increasing its flexibility.