### PR TITLE
Adjust to new Firecrown modules structure for v1.15

### DIFF
--- a/examples/cosmic_shear/cosmicshear_likelihood.py
+++ b/examples/cosmic_shear/cosmicshear_likelihood.py
@@ -8,16 +8,25 @@ import sacc
 import pathlib
 from packaging.version import Version
 import firecrown
-if Version(firecrown.__version__) >= Version("1.8"):
+
+# Handle different Firecrown versions
+if Version(firecrown.__version__) >= Version("1.15.0a0"):
+    # New structure (1.15.0a0+)
+    from firecrown.likelihood import weak_lensing as wl
+    from firecrown.likelihood import TwoPoint
+    from firecrown.likelihood import ConstGaussian
+elif Version(firecrown.__version__) >= Version("1.8"):
+    # Intermediate structure (1.8 - 1.14.x)
     import firecrown.likelihood.weak_lensing as wl
     from firecrown.likelihood.two_point import TwoPoint
     from firecrown.likelihood.gaussian import ConstGaussian
 else:
+    # Old structure (< 1.8)
     import firecrown.likelihood.gauss_family.statistic.source.weak_lensing as wl
     from firecrown.likelihood.gauss_family.statistic.two_point import TwoPoint
     from firecrown.likelihood.gauss_family.gaussian import ConstGaussian
+
 from firecrown.modeling_tools import ModelingTools
-# from firecrown.likelihood.likelihood import NamedParameters
 
 
 def build_likelihood(build_parameters):

--- a/examples/supernovae/sn_likelihood.py
+++ b/examples/supernovae/sn_likelihood.py
@@ -6,15 +6,25 @@ import sacc
 import pathlib
 from packaging.version import Version
 import firecrown
-if Version(firecrown.__version__) >= Version("1.8"):
-    # future proofing for firecrown 1.8
+
+# Handle different Firecrown versions
+if Version(firecrown.__version__) >= Version("1.15.0a0"):
+    # New structure (1.15.0a0+)
+    from firecrown.likelihood import supernova as sn
+    from firecrown.likelihood import ConstGaussian
+    from firecrown.likelihood import NamedParameters
+elif Version(firecrown.__version__) >= Version("1.8"):
+    # Intermediate structure (1.8 - 1.14.x)
     import firecrown.likelihood.supernova as sn
     from firecrown.likelihood.gaussian import ConstGaussian
+    from firecrown.likelihood.likelihood import NamedParameters
 else:
+    # Old structure (< 1.8)
     from firecrown.likelihood.gauss_family.statistic import supernova as sn
     from firecrown.likelihood.gauss_family.gaussian import ConstGaussian
+    from firecrown.likelihood.likelihood import NamedParameters
+
 from firecrown.modeling_tools import ModelingTools
-from firecrown.likelihood.likelihood import NamedParameters
 
 
 def build_likelihood(build_parameters: NamedParameters):

--- a/src/smokescreen/datavector.py
+++ b/src/smokescreen/datavector.py
@@ -24,11 +24,27 @@ import inspect
 import datetime
 import getpass
 from copy import deepcopy
+from packaging.version import Version
 import pyccl as ccl
 import sacc
-from firecrown.likelihood.likelihood import load_likelihood
-from firecrown.likelihood.likelihood import load_likelihood_from_module_type
-from firecrown.likelihood.likelihood import NamedParameters
+import firecrown
+
+# Handle different Firecrown versions
+if Version(firecrown.__version__) >= Version("1.15.0a0"):
+    # New structure (1.15.0a0+)
+    from firecrown.likelihood import (
+        load_likelihood,
+        load_likelihood_from_module_type,
+        NamedParameters
+    )
+else:
+    # Old structure (< 1.15.0a0)
+    from firecrown.likelihood.likelihood import (
+        load_likelihood,
+        load_likelihood_from_module_type,
+        NamedParameters
+    )
+
 from firecrown.parameters import ParamsMap
 from firecrown.updatable import get_default_params_map
 from firecrown.utils import save_to_sacc

--- a/tests/test_datavector.py
+++ b/tests/test_datavector.py
@@ -3,10 +3,18 @@ import types
 import os
 import datetime
 from unittest.mock import patch, MagicMock  # noqa: F401
+from packaging.version import Version
 import numpy as np
 import sacc
 import pyccl as ccl
-from firecrown.likelihood.likelihood import Likelihood
+import firecrown
+
+# Handle different Firecrown versions
+if Version(firecrown.__version__) >= Version("1.15.0a0"):
+    from firecrown.likelihood import Likelihood
+else:
+    from firecrown.likelihood.likelihood import Likelihood
+
 from firecrown.modeling_tools import ModelingTools
 from smokescreen.datavector import ConcealDataVector
 ccl.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = False


### PR DESCRIPTION
This PR modifies the imports in Smokescreen to adapt to the upcoming Firecrown v1.15 release, which has a modified module structure. The changes are backwards compatible with old Firecrown versions.